### PR TITLE
Create .npmrc during deployment as needed

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,6 +25,7 @@ deploy_script:
   - ps: |
       if ($ENV:CONFIGURATION -eq "publish")
       {
+        "//registry.npmjs.org/:_authToken=`$`{NPM_TOKEN`}" | Out-File ".npmrc"
         iex "npm pack"
         iex "npm publish"
       }

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
This fixes the local `npm install` not working when the `NPM_TOKEN` environment variable is not set.